### PR TITLE
Bug fixes

### DIFF
--- a/kauai/src/docb.cpp
+++ b/kauai/src/docb.cpp
@@ -236,7 +236,7 @@ tribool DOCB::_TQuerySave(bool fForce)
 {
     AssertThis(0);
 
-    return vpappb->TQuerySaveDoc(this, fForce) ? tYes : tNo;
+    return vpappb->TQuerySaveDoc(this, fForce);
 }
 
 /***************************************************************************

--- a/src/compress.zig
+++ b/src/compress.zig
@@ -78,8 +78,8 @@ pub fn Decompress(comptime ReaderType: type) type {
                     else => unreachable,
                 };
 
-                count_ones = countOnes(&source, 11);
-                if (count_ones.limit_or_eof and count_ones.count < 11) {
+                count_ones = countOnes(&source, 12);
+                if (count_ones.limit_or_eof and count_ones.count < 12) {
                     return error.CorruptedData;
                 }
 


### PR DESCRIPTION
Adds a couple bug fixes.

- When querying save changes before exiting the app, if the user chooses "keep working, save later" the game would just quit and save changes.
- Sometimes unpacking a compressed KCDC chunk would fail. Oops!